### PR TITLE
CMakeLists.txt: do create uninstall target only if not yet created

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,11 +32,13 @@ include(KDECompilerSettings)
 include(FeatureSummary)
 
 # Add custom uninstall target
-configure_file(
-    "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
-    "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
-    IMMEDIATE @ONLY)
-add_custom_target(uninstall "${CMAKE_COMMAND}" -P "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake")
+if (NOT TARGET uninstall)
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+        IMMEDIATE @ONLY)
+    add_custom_target(uninstall "${CMAKE_COMMAND}" -P "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake")
+endif()
 
 # Set up packaging
 set(CPACK_PACKAGE_NAME "pss")


### PR DESCRIPTION
later versions of ECM create unsinstall target by default and cmake
failes with:

| CMake Error at CMakeLists.txt:39 (add_custom_target):
|   add_custom_target cannot create target "uninstall" because another target
|   with the same name already exists.  The existing target is a custom target
|   created in source directory
|   "...".
|   See documentation for policy CMP0002 for more details.

Signed-off-by: Andreas Müller schnitzeltony@googlemail.com
